### PR TITLE
Update documentation to direct users to AMS 2024 regionalization workflow, with minor workflow updates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -28,3 +28,10 @@ cd NWMv4/ams2024
 3. `python main_identify_donors.py`
 
 4. Explore the output 
+The outputs contain the following columns:
+-`id`: receiver catchment ID	
+-`tag`: regionalization method	
+-`donor`: selected donor catchment from regionalization	
+-`distSpatial`:	spatial distance between donor and receiver pair (km)
+-`donors`: top 3 potential donor catchments	
+-`distSpatials`: spatial distnaces between the top 3 potential donor catchments and the receiver catchment (km)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,7 +23,7 @@ cd NextGen_Regionalization
 cd NWMv4/ams2024 
 ```
 
-2. Download the [hydrofabric data](https://www.lynker-spatial.com/#hydrofabric/v20.1/gpkg/) for HUC 12 (Texas-Gulf Region) to `NextGen_Regionalization/NWMv4/datasets/nextgen_12.gpkg`
+2. Download the [hydrofabric data](https://www.lynker-spatial.com/#hydrofabric/v20.1/gpkg/) for [HUC 12](https://www.lynker-spatial.com/#hydrofabric/v20.1/gpkg/nextgen_12.gpkg) (Texas-Gulf Region) to `NextGen_Regionalization/NWMv4/data/nextgen_12.gpkg`
 
 3. `python main_identify_donors.py`
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,3 +1,30 @@
 # Installation instructions
 
-Detailed instructions on how to install, configure, and get the project running.
+Detailed instructions on how to clone and run NextGen_Regionalization are provided below. The workflow requires the following Python libraries:
+  * `yaml` (`pip install pyyaml`)
+  * `scikit-learn` 
+  * `scikit-learn-extra`
+  * `matplotlib`
+  * `geopandas` 
+  * `hdbscan`
+  * `numba` 
+
+## Clone the repository
+```
+git clone https://github.com/NOAA-OWP/NextGen_Regionalization
+cd NextGen_Regionalization
+```
+
+## Run the Example Regionalization Workflow ([presented at AMS 2024](https://docs.google.com/presentation/d/1xkYs-Hs3_cmIheLZ1Di7Dy3vWaiL3jmx/edit?usp=sharing&ouid=117267696082803250432&rtpof=true&sd=true))
+0. Activate the virtual python environment with all dependencies installed
+
+1. Go to the example directory
+```
+cd NWMv4/ams2024 
+```
+
+2. Download the [hydrofabric data](https://www.lynker-spatial.com/#hydrofabric/v20.1/gpkg/) for HUC 12 (Texas-Gulf Region) to `NextGen_Regionalization/NWMv4/datasets/nextgen_12.gpkg`
+
+3. `python main_identify_donors.py`
+
+4. Explore the output 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,9 +29,9 @@ cd NWMv4/ams2024
 
 4. Explore the output 
 The outputs contain the following columns:
--`id`: receiver catchment ID	
--`tag`: regionalization method	
--`donor`: selected donor catchment from regionalization	
--`distSpatial`:	spatial distance between donor and receiver pair (km)
--`donors`: top 3 potential donor catchments	
--`distSpatials`: spatial distnaces between the top 3 potential donor catchments and the receiver catchment (km)
+* `id`: receiver catchment ID	
+* `tag`: regionalization method	
+* `donor`: selected donor catchment from regionalization	
+* `distSpatial`:	spatial distance between donor and receiver pair (km)
+* `donors`: top 3 potential donor catchments	
+* `distSpatials`: spatial distnaces between the top 3 potential donor catchments and the receiver catchment (km)

--- a/NWMv4/algorithm/unsupervised_random_forest.py
+++ b/NWMv4/algorithm/unsupervised_random_forest.py
@@ -17,7 +17,7 @@ from numba import njit
 import synthetic_data
 
 class urf(object):
-    def __init__(self, n_trees = 100, synthetic_data_type = None, max_features='auto', max_depth=None):
+    def __init__(self, n_trees = 100, synthetic_data_type = None, max_features='sqrt', max_depth=None):
 
         self.n_trees = n_trees
         self.synthetic_data_type = synthetic_data_type

--- a/NWMv4/ams2024/data/config_huc12.yaml
+++ b/NWMv4/ams2024/data/config_huc12.yaml
@@ -41,7 +41,7 @@ attrs:
 inputs:
   
   # path to hydrofabric file (download at https://www.lynker-spatial.com/#hydrofabric/v20.1/gpkg/)
-  file_hydrofab: ../datasets/nextgen_{huc}.gpkg
+  file_hydrofab: ../data/nextgen_{huc}.gpkg
 
   # file for attribute data for all catchments (donors & receivers)
   file_attrs_data: ../attr_calc/output/all_attrs_huc{huc}_v{ver}.csv

--- a/NWMv4/ams2024/data/config_huc12.yaml
+++ b/NWMv4/ams2024/data/config_huc12.yaml
@@ -21,6 +21,7 @@ algorithms:
   kmedoids: TRUE
   hdbscan: TRUE
   birch: TRUE
+  proximity: TRUE
 
 ### number of parallel jobs to run
 njobs: 20
@@ -39,11 +40,11 @@ attrs:
 ### inputs
 inputs:
   
-  # path to hydrofabric file
-  file_hydrofab: ../../datasets/gpkg_v{ver}/nextgen_huc{huc}.gpkg
+  # path to hydrofabric file (download at https://www.lynker-spatial.com/#hydrofabric/v20.1/gpkg/)
+  file_hydrofab: ../datasets/nextgen_{huc}.gpkg
 
   # file for attribute data for all catchments (donors & receivers)
-  file_attrs_data: ../output_attr/all_attrs_huc{huc}_v{ver}.csv
+  file_attrs_data: ../attr_calc/output/all_attrs_huc{huc}_v{ver}.csv
   
   # file containing list of donor basins (USGS gage ID)
   #file_donor_list: ../data/donor_gages_huc{huc}_screened.csv

--- a/NWMv4/ams2024/main_identify_donors.py
+++ b/NWMv4/ams2024/main_identify_donors.py
@@ -30,7 +30,7 @@ import funcs_dist
 import my_utils
 
 # read configuration (algorithm parameters etc)
-with open('data/config.yaml', 'r') as stream:
+with open('data/config_huc12.yaml', 'r') as stream:
     try:
         config = yaml.safe_load(stream)
     except yaml.YAMLError as exc:
@@ -69,7 +69,7 @@ print('Total number of calibration basins: ' + str(len(set(cwt.loc[cwt['gages'].
 # sort the rows so that donors are at the top
 dfAttrAll = dfAttrAll.sort_values(by="tag")
 
-# detemine whether the catchment is snowy (as snowy and non-snowy catchments are processed separately)
+# determine whether the catchment is snowy (as snowy and non-snowy catchments are processed separately)
 dfAttrAll['snowy'] = dfAttrAll['snow_frac'].apply(lambda x: True if x >= config['pars']['general']['minSnowFrac'] else False)
 
 # columns in the attrs table that are not actual attributes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Parameter/Fomulation Regionalization for NextGen
+# Parameter/Formulation Regionalization for NextGen
 
 **Description**: NextGen regionalization is adapted from the NWMv3.0 regionalization framework, which uses a physical similarity-based approach to transfer model formulations and parameters from calibrated basins (donors) to uncalibrated areas (receivers). Currently, the framework considers two different sets of basin attributes to represent physical similarity: Hydrologic Landscape Regions (HLR, Winter 2001 and Wolock et al. 2004 ) and Catchment Attributes and Meteorology for Large-sample Studies (CAMELS, Addor et al. 2017). 
 
@@ -21,7 +21,14 @@
 
 ## Dependencies
 
-The scripts use the python libary [scikit-learn](https://scikit-learn.org/stable/modules/clustering.html) as well as R libraries including the zonal package in the [hydrofabric](https://github.com/NOAA-OWP/hydrofabric) tools 
+The scripts use the following Python libraries:
+  * `yaml`
+  * `scikit-learn`  
+  * `scikit-learn-extra`
+  * `matplotlib`
+  * `geopandas` 
+  * `hdbscan`
+  * `numba` 
 
 ## Credits and references
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The scripts use the following Python libraries:
   * `hdbscan`
   * `numba` 
 
+## Build and Run Instructions
+Detailed instructions on how to install and run the NextGen_Regionalization workflow can be found in the [INSTALL](https://github.com/NOAA-OWP/NextGen_Regionalization/blob/master/INSTALL.md) guide.
+ - Test example highlights
+   - Clone the NextGen_Regionalization repo
+   - Replicate the donor/receiver pairing results from AMS 2024 for HUC 12 (Texas-Gulf Region) (see [the presentation slides](https://docs.google.com/presentation/d/1xkYs-Hs3_cmIheLZ1Di7Dy3vWaiL3jmx/edit?usp=sharing&ouid=117267696082803250432&rtpof=true&sd=true))
+   
 ## Credits and references
 
 **Acknowlegement**: The NextGen regionalization framework was adapted from the NWM v3 regionalization work and has benefited from discussions and help from the NWM calibration team, as well as the valuable feedback from the RFCs.


### PR DESCRIPTION
I updated the documentation to make it clear where users could find a functional example of the Nextgen Regionalization workflow (prepared for AMS 2024). 

## Additions

- Updates to the README.md and INSTALL.md to tell users how to prepare and run the example workflow
- Specify Python dependencies
- Specify that the example workflow can be run successfully for HUC 12 in particular

## Removals

- None

## Changes

- Updated some relative paths
- Minor update to unsupervised random forest default option (previous option was deprecated)

## Testing

1. I ran the main script for the example workflow `main_identify_donors.py` to confirm that changes run smoothly.
